### PR TITLE
Fixed test run warning

### DIFF
--- a/src/visualisation.py
+++ b/src/visualisation.py
@@ -72,3 +72,4 @@ def draw(g: Graph, filename: str = "test_draw.png"):
     plt.savefig(filename)
     plt.cla()
     plt.clf()
+    plt.close()


### PR DESCRIPTION
(too many images open)

```
/home/.../src/visualisation.py:55: RuntimeWarning: More than 20 figures have been opened.
Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly
closed and may consume too much memory.(To control this warning, see the rcParam `figure.max_open_warning`)

Consider using `matplotlib.pyplot.close()`.
```